### PR TITLE
[#95964696] Rebase config and remove deprecate items

### DIFF
--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -1,159 +1,50 @@
 listen: "0.0.0.0:{{api_port}}"
 admin-listen: "0.0.0.0:8081"
-
 host: http://{{tsuru_api_internal_lb}}:{{api_port}}
-
-# Uncomment the following lines to enable HTTPS on Tsuru. You will need the
-# paths to the certificate and key files.
-#
-# use-tls: true
-# tls-cert-file: /path/to/cert.pem
-# tls-key-file: /path/to/key.pem
-
-# Database configuration. Tsuru API needs a MongoDB server. By default, it will
-# connect on localhost, in the default port, and use the database "tsuru".
-# Uncomment and customize the lines below to change these values.
-#
+#use-tls: true
+#tls-cert-file: /path/to/cert.pem
+#tls-key-file: /path/to/key.pem
 database:
    url: {{mongodb_host}}:{{mongodb_port}}
    name: tsuru
-
-# Git configuration. These settings refer to Gandalf, the git management tool
-# used by Tsuru.
-#
-#   * unit-repo: it's the path where Tsuru will clone app code in units. This
-#                value should not change after its initial definition.
-#   * api-server: HTTP URL where Gandalf is accessible. Tsuru will use this URL
-#                 to create users and repositories.
-#   * rw-host: rw-host is the host string that will be used for reading and
-#              writing in Git repositories. It will be used to build the SSH
-#              URL for the git repository, and need to be accessible from the
-#              internet.
-#   * ro-host: ro-host is the host string that will be used for reading data
-#              from Git repositories. It will be used to build the read-only
-#              URL for the repository. This host need to be accessible from
-#              units. You may use the private IP of the Gandalf host.
 git:
   unit-repo: /home/application/current
   rw-host: http://{{ gandalf_host_external }}:{{ gandalf_port }}
   api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
-
-# S3 Bucket support. When this flag is defined as true, Tsuru will create a S3
-# bucket per application. Bucket creation depends on AWS settings (next
-# section).
-#
-# bucket-support: false
-
-# AWS configuration. Tsuru communicates with AWS to manage user credentials on
-# IAM, load balancers on ELB and buckets on S3.
-#
-# Uncomment these settings if you want to create S3 buckets and manage ELB
-# instances per app.
-#
-# aws:
-#   access-key-id: access-id-here
-#   secret-access-key: secret-very-secret
-#   ec2:
-#     endpoint: https://ec2.us-east-1.amazonaws.com
-#   iam:
-#     endpoint: https://iam.amazonaws.com/
-#   s3:
-#     region-name: us-west-1
-#     endpoint: https://ec2.us-west-1.amazonaws.com
-#     bucketEndpoint: https://s3-us-west-1.amazonaws.com
-#     location-constraint: true
-#     lowercase-bucket: true
-
-# Authentication configuration.
-#
-#    * token-expire-days: this option controls the time (in days) for a token
-#                         to expire.
-#    * hash-cost: Tsuru uses bcrypt for password hashing, here you can control
-#                 the cost of the hashing.
-#    * user-registration: by default, users are not able to register themselves
-#                         in Tsuru server (via the "user-create" command).
-#                         Changing this options to true enables the user-create
-#                         command.
-#
+#bucket-support: false
+#aws:
+#  access-key-id: access-id-here
+#  secret-access-key: secret-very-secret
+#  ec2:
+#    endpoint: https://ec2.us-east-1.amazonaws.com
+#  iam:
+#    endpoint: https://iam.amazonaws.com/
+#  s3:
+#    region-name: us-west-1
+#    endpoint: https://ec2.us-west-1.amazonaws.com
+#    bucketEndpoint: https://s3-us-west-1.amazonaws.com
+#    location-constraint: true
+#    lowercase-bucket: true
 auth:
    schema: native
    user-registration: true
-
-# Tsuru uses provisioners for creating units per app. There are two
-# provisioners: Docker and Juju. In order to use the Juju provisioner, you need
-# to uncomment the lines below and specify the settings you need.
-#
-# Juju configuration includes the following options:
-#
-#    * charms-path: the path to the local charms distribution. Tsuru's charms
-#                   are hosted at github.com/globocom/charms.
-#    * units-collection: the name of the database collection that Juju
-#                        provisioner will use to store information about its
-#                        units.
-#    * use-elb: when defined as true, Juju provisioner will create ELB
-#               instances when provisioning a new app.
-#    * elb-endpoint: HTTP endpoint to the Elastic Load Balancing API.
-#    * elb-collection: the name of the database collection the Juju provision
-#                      will use to store information about ELB instances.
-#    * elb-avail-zones: list of availability zones for the load balancer. This
-#                       option is not necessary in VPC mode.
-#    * elb-use-vpc: defines whether ELB instances should use VPC or ordinary
-#                   EC2 networking. When in VPC mode, all load balancers will
-#                   be created in internal mode. For more details, check AWS
-#                   docs: https://aws.amazon.com/elasticloadbalancing.
-#    * elb-vpc-subnets: list of subnets to use in VPC mode.
-#    * elb-vpc-secgroups: list of security groups to use in VPC mode.
-#
-# provisioner: juju
-# juju:
-#   bootstrap-collection: juju_bootstrap
-#   charms-path: /home/charms
-#   units-collection: juju_units
-#   use-elb: false
-#   elb-endpoint: https://elasticloadbalancing.amazonaws.com
-#   elb-collection: juju_load_balancers
-#   elb-avail-zones:
-#     - us-west-1a
-#   elb-use-vpc: false
-#   elb-vpc-subnets:
-#     - network1
-#     - network2
-#   elb-vpc-secgroups:
-#     - secgroup1
-#     - secgroup2
-
-# Below are settings for the Docker provisioner. Tsuru uses Docker in a
-# clustered environment, so there are some settings related to the scheduling
-# of containers in the cluster.
-#
-#    * servers: list of docker servers. Used in non-segregated mode (see
-#               segregate for more details).
-#    * collection: name of the database collection that Docker provisioner will
-#                  use to store information about containers in the cluster.
-#    * repository-namespace: the namespace to use in Docker images. For
-#                            instance, an app named blog will have an image
-#                            <namespace>/blog.
-#    * router: the router to use.
-#    * deploy-cmd: command to run every time user runs deploy. When using
-#                  Tsuru's default images, just uncomment the line.
-#    * segregate: indicates whether tsuru should use a scheduler that
-#                  segregates containers among Docker nodes. When using this
-#                  scheduler, each team will have a group of Docker nodes and
-#                  Tsuru will spawn new containers for that team only on these
-#                  nodes. This scheduler can be used to segregate subnets per
-#                  team.
-#    * scheduler: configuration for the scheduler. In order to make the
-#                  cluster run faster, it's recommended to use the Redis
-#                  storage. It will store the relation between containers and
-#                  nodes.
-#    * run-cmd: command that will start the application. Also includes the port
-#               that will be used for redirecting traffic. This is the port
-#               that applications should bind.
-#    * ssh: Tsuru will start the container with a SSH server. This section
-#               contains options that describe which command will be used to
-#               add the public key to containers, the public key path, the user
-#               and the path to the SSH server (which is optional).
-#
+#provisioner: juju
+#juju:
+#  bootstrap-collection: juju_bootstrap
+#  charms-path: /home/charms
+#  units-collection: juju_units
+#  use-elb: false
+#  elb-endpoint: https://elasticloadbalancing.amazonaws.com
+#  elb-collection: juju_load_balancers
+#  elb-avail-zones:
+#    - us-west-1a
+#  elb-use-vpc: false
+#  elb-vpc-subnets:
+#    - network1
+#    - network2
+#  elb-vpc-secgroups:
+#    - secgroup1
+#    - secgroup2
 provisioner: docker
 hipache:
    domain: {{hipache_host_external_lb}}
@@ -181,25 +72,12 @@ docker:
       storage: mongodb
       mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
       mongo-database: cluster
-
-# The address of the queue server (beanstalkd). By default, it's
-# 127.0.0.1:11300. Uncomment and change for connecting in a different
-# Beanstalkd instance.
-#
 # queue-server: "127.0.0.1:11300"
-
 queue: redis
 redis-queue:
    host: {{redis_host}}
    port: {{ redis_port}}
-
-# The name of the admin team. When ommited, no team will be able to administrate Tsuru.
-#
 admin-team: admin
-
-# Quota information. Tsuru supports two kind of quotas: number of units per app
-# and number of apps per user.
-#
 # quota:
 #   units-per-app: 2
 #   apps-per-user: 2

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -27,7 +27,6 @@ docker:
   repository-namespace: tsuru
   router: hipache
   deploy-cmd: /var/lib/tsuru/deploy
-  segregate: false
   run-cmd:
     bin: /var/lib/tsuru/start
     port: "8888"

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -37,9 +37,9 @@ routers:
     domain: {{hipache_host_external_lb}}
     redis-server: {{redis_host}}:{{redis_port}}
 queue: redis
-redis-queue:
-  host: {{redis_host}}
-  port: {{ redis_port}}
+pubsub:
+  redis-host: {{redis_host}}
+  redis-port: {{ redis_port}}
 admin-team: admin
 #quota:
 #  units-per-app: 2

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -1,5 +1,4 @@
 listen: "0.0.0.0:{{api_port}}"
-admin-listen: "0.0.0.0:8081"
 host: http://{{tsuru_api_internal_lb}}:{{api_port}}
 #use-tls: true
 #tls-cert-file: /path/to/cert.pem

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -5,42 +5,42 @@ host: http://{{tsuru_api_internal_lb}}:{{api_port}}
 #tls-cert-file: /path/to/cert.pem
 #tls-key-file: /path/to/key.pem
 database:
-   url: {{mongodb_host}}:{{mongodb_port}}
-   name: tsuru
+  url: {{mongodb_host}}:{{mongodb_port}}
+  name: tsuru
 git:
   api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
   unit-repo: /home/application/current
   rw-host: http://{{ gandalf_host_external }}:{{ gandalf_port }}
 auth:
-   schema: native
-   user-registration: true
+  schema: native
+  user-registration: true
 provisioner: docker
 hipache:
-   domain: {{hipache_host_external_lb}}
-   redis-server: {{redis_host}}:{{redis_port}}
+  domain: {{hipache_host_external_lb}}
+  redis-server: {{redis_host}}:{{redis_port}}
 docker:
-   cluster:
-      storage: mongodb
-      mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
-      mongo-database: cluster
-   registry: {{ docker_registry_host }}:{{ docker_registry_port }}
-   collection: docker
-   repository-namespace: tsuru
-   router: hipache
-   deploy-cmd: /var/lib/tsuru/deploy
-   segregate: false
-   run-cmd:
-     bin: /var/lib/tsuru/start
-     port: "8888"
-   ssh:
-     add-key-cmd: /var/lib/tsuru/add-key
-#     public-key: /home/ubuntu/.ssh/id_rsa.pub
-     user: ubuntu
+  cluster:
+    storage: mongodb
+    mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
+    mongo-database: cluster
+  registry: {{ docker_registry_host }}:{{ docker_registry_port }}
+  collection: docker
+  repository-namespace: tsuru
+  router: hipache
+  deploy-cmd: /var/lib/tsuru/deploy
+  segregate: false
+  run-cmd:
+    bin: /var/lib/tsuru/start
+    port: "8888"
+  ssh:
+    add-key-cmd: /var/lib/tsuru/add-key
+#    public-key: /home/ubuntu/.ssh/id_rsa.pub
+    user: ubuntu
 queue: redis
 redis-queue:
-   host: {{redis_host}}
-   port: {{ redis_port}}
+  host: {{redis_host}}
+  port: {{ redis_port}}
 admin-team: admin
-# quota:
-#   units-per-app: 2
-#   apps-per-user: 2
+#quota:
+#  units-per-app: 2
+#  apps-per-user: 2

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -14,9 +14,6 @@ auth:
   schema: native
   user-registration: true
 provisioner: docker
-hipache:
-  domain: {{hipache_host_external_lb}}
-  redis-server: {{redis_host}}:{{redis_port}}
 docker:
   cluster:
     storage: mongodb
@@ -34,6 +31,11 @@ docker:
     add-key-cmd: /var/lib/tsuru/add-key
 #    public-key: /home/ubuntu/.ssh/id_rsa.pub
     user: ubuntu
+routers:
+  hipache:
+    type: hipache
+    domain: {{hipache_host_external_lb}}
+    redis-server: {{redis_host}}:{{redis_port}}
 queue: redis
 redis-queue:
   host: {{redis_host}}

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -8,9 +8,9 @@ database:
    url: {{mongodb_host}}:{{mongodb_port}}
    name: tsuru
 git:
+  api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
   unit-repo: /home/application/current
   rw-host: http://{{ gandalf_host_external }}:{{ gandalf_port }}
-  api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
 auth:
    schema: native
    user-registration: true
@@ -19,6 +19,10 @@ hipache:
    domain: {{hipache_host_external_lb}}
    redis-server: {{redis_host}}:{{redis_port}}
 docker:
+   cluster:
+      storage: mongodb
+      mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
+      mongo-database: cluster
    registry: {{ docker_registry_host }}:{{ docker_registry_port }}
    collection: docker
    repository-namespace: tsuru
@@ -32,10 +36,6 @@ docker:
      add-key-cmd: /var/lib/tsuru/add-key
 #     public-key: /home/ubuntu/.ssh/id_rsa.pub
      user: ubuntu
-   cluster:
-      storage: mongodb
-      mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
-      mongo-database: cluster
 queue: redis
 redis-queue:
    host: {{redis_host}}

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -11,40 +11,9 @@ git:
   unit-repo: /home/application/current
   rw-host: http://{{ gandalf_host_external }}:{{ gandalf_port }}
   api-server: http://{{ gandalf_host_internal }}:{{ gandalf_port }}
-#bucket-support: false
-#aws:
-#  access-key-id: access-id-here
-#  secret-access-key: secret-very-secret
-#  ec2:
-#    endpoint: https://ec2.us-east-1.amazonaws.com
-#  iam:
-#    endpoint: https://iam.amazonaws.com/
-#  s3:
-#    region-name: us-west-1
-#    endpoint: https://ec2.us-west-1.amazonaws.com
-#    bucketEndpoint: https://s3-us-west-1.amazonaws.com
-#    location-constraint: true
-#    lowercase-bucket: true
 auth:
    schema: native
    user-registration: true
-#provisioner: juju
-#juju:
-#  bootstrap-collection: juju_bootstrap
-#  charms-path: /home/charms
-#  units-collection: juju_units
-#  use-elb: false
-#  elb-endpoint: https://elasticloadbalancing.amazonaws.com
-#  elb-collection: juju_load_balancers
-#  elb-avail-zones:
-#    - us-west-1a
-#  elb-use-vpc: false
-#  elb-vpc-subnets:
-#    - network1
-#    - network2
-#  elb-vpc-secgroups:
-#    - secgroup1
-#    - secgroup2
 provisioner: docker
 hipache:
    domain: {{hipache_host_external_lb}}
@@ -56,10 +25,6 @@ docker:
    router: hipache
    deploy-cmd: /var/lib/tsuru/deploy
    segregate: false
-#   scheduler:
-#     redis-server: 127.0.0.1:6379
-#     redis-prefix: docker-cluster
-#     redis-password: s3cr3t
    run-cmd:
      bin: /var/lib/tsuru/start
      port: "8888"
@@ -67,12 +32,10 @@ docker:
      add-key-cmd: /var/lib/tsuru/add-key
 #     public-key: /home/ubuntu/.ssh/id_rsa.pub
      user: ubuntu
-#     sshd-path: /usr/sbin/sshd
    cluster:
       storage: mongodb
       mongo-url: {{ mongodb_host }}:{{ mongodb_port }}
       mongo-database: cluster
-# queue-server: "127.0.0.1:11300"
 queue: redis
 redis-queue:
    host: {{redis_host}}


### PR DESCRIPTION
Principally so that we can bring up machines with the recently released Tsuru 0.11.1, but also so that we get less deprecation warnings and that it's easier to maintain in future. Details in the individual commits.
