### PR TITLE
Don't install jq package

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,4 +6,3 @@ packages:
   - tsuru-server
   - tsuru-admin
   - tsuru-client
-  - jq


### PR DESCRIPTION
This was used by alphagov/tsuru-ansible to parse the login token. It's no
longer needed now that we use Ansible's `uri` module and parse the JSON in
Jinga2.

alphagov/tsuru-ansible@6abc02119c8f18ed7f03422a83a8f55d9f03d32c
