### PR TITLE
[#93541780] Listen options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for tsuru_api
 
 tsuru_api_listen_port: 8080
+tsuru_api_listen_addr: "0.0.0.0"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for tsuru_api
 
+tsuru_api_listen_port: 8080

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Configure tsuru-admin command.
   shell: >
     tsuru-admin target-remove local;
-    tsuru-admin target-add local http://127.0.0.1:{{api_port}} -s
+    tsuru-admin target-add local http://127.0.0.1:{{ tsuru_api_listen_port }} -s
 
 - name: Wait for tsuru-server to be up
-  wait_for: port={{api_port}} timeout=60
+  wait_for: port={{ tsuru_api_listen_port }} timeout=60

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -1,4 +1,4 @@
-listen: "0.0.0.0:{{ tsuru_api_listen_port }}"
+listen: "{{ tsuru_api_listen_addr }}:{{ tsuru_api_listen_port }}"
 host: {{ tsuru_api_url | mandatory }}
 #use-tls: true
 #tls-cert-file: /path/to/cert.pem

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -1,5 +1,5 @@
 listen: "0.0.0.0:{{api_port}}"
-host: http://{{tsuru_api_internal_lb}}:{{api_port}}
+host: {{ tsuru_api_url | mandatory }}
 #use-tls: true
 #tls-cert-file: /path/to/cert.pem
 #tls-key-file: /path/to/key.pem

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -1,4 +1,4 @@
-listen: "0.0.0.0:{{api_port}}"
+listen: "0.0.0.0:{{ tsuru_api_listen_port }}"
 host: {{ tsuru_api_url | mandatory }}
 #use-tls: true
 #tls-cert-file: /path/to/cert.pem


### PR DESCRIPTION
#### Replace tsuru_api_internal_lb with tsuru_api_url

Add a new variable that is mandatory and has no default to define the URL
that the API can be accessed by internally and externally.

This is safer and makes more sense than constructing it from the two
variables because:
- `tsuru_api_internal_lb` is an implementation detail inside the repo
  alphagov/tsuru-ansible, from before this role was split out to a separate
  repo
- the protocol and `api_port` may no longer be correct when this service is
  frontend by an SSL reverse proxy
#### Replace api_port with tsuru_api_listen_port

In some hope of namespacing and scoping variables passed into this role.
Also sets a sensible default if nothing is provided.
#### Add tsuru_api_listen_addr variable

So that we can bind the API to localhost and front it with an SSL reverse
proxy without exposing the HTTP interface.

---

The next release should be tagged as 0.1.0 because these are breaking changes.
