### PR TITLE
[#91513820] Add support for autohealing in tsuru

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Role Variables
 --------------
 
 * `api_port` - Port upon which you wish to run the API server
+* `healing_active_monitoring_interval` - Number of seconds between calls to `<server>/_ping` in each one of the docker nodes, [for more information check here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-active-monitoring-interval)
+* `healing_heal_containers_timeout` - Number of seconds a container should be unresponsive before triggering the recreation of the container, [for more information check here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-heal-containers-timeout)
 * `tsuru_api_internal_lb` - The hostname of the loadbalancer you wish to run tsuru behind.
 * `mongodb_host` - MongoDB hostname
 * `mongodb_port` - MongoDB server portnumber

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 # defaults file for tsuru_api
 
+healing_active_monitoring_interval: 10
+healing_heal_containers_timeout: 10
+
 tsuru_api_listen_port: 8080
 tsuru_api_listen_addr: "0.0.0.0"

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -31,6 +31,9 @@ docker:
     add-key-cmd: /var/lib/tsuru/add-key
 #    public-key: /home/ubuntu/.ssh/id_rsa.pub
     user: ubuntu
+  healing:
+    active-monitoring-interval: {{ healing_active_monitoring_interval }}
+    heal-containers-timeout: {{ healing_heal_containers_timeout }}
 routers:
   hipache:
     type: hipache


### PR DESCRIPTION
[Application healing](https://www.pivotaltracker.com/story/show/91513820)

**What**

In order to make `Tsuru` autoheal we need to add two new settings:
- `healing_active_monitoring_interval` - Number of seconds between calls
  to `<server>/_ping` in each one of the docker nodes,
  [for more information check here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-active-monitoring-interval)
- `healing_heal_containers_timeout` - Number of seconds a container
  should be unresponsive before triggering the recreation of the
  container, [for more information check here](http://tsuru.readthedocs.org/en/stable/reference/config.html?highlight=unit#docker-healing-heal-containers-timeout)

**How to test**
- Modify `requirements.yml`:

```
 - name: tsuru_api
   src: https://github.com/alphagov/ansible-playbook-tsuru_api.git
-  version: v0.0.3
+  version: v0.0.4
```
- Deploy application e.g. `dashboard` into `Tsuru` environment with more than 1 `docker node`
- Login into `tsuru-api` server using `tsuru` client and run `tsuru app-list` to identify application e.g. `dashboard`
- Run `watch -n 10 "tsuru app-info -a dashboard && tsuru-admin docker-node-list"` 
- Note the `docker` node that the `dashboard` application is running on
- In another terminal window login to the `docker` node that the `dashboard` application is running on and run `sudo poweroff` to shut it down
- In under one minute the application will have started on another `docker` node
- To get more detailed information on the self healing process add `debug: true` to `/etc/tsuru/tsuru.conf`

**Who should review this PR**
- Anyone in the core team.
