### PR TITLE
[#98748824] Pin tsuru-api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Role Variables
 * `redis_port` - The redis port.
 * ` docker_registry_host ` - The Docker registry hostname.
 * ` docker_registry_port ` - The Docker registry port.
+* `tsuru_server_version` - The version of the tsuru server package to be installed
+* `tsuru_client_version` - The version of the tsuru client package to be installed
+* `tsuru_admin_version` - The version of the tsuru admin package to be installed
 
 
 Dependencies

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "tsuru-api"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "test.yml"
+  end
+end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,11 @@
 
 - name: Install packages.
   apt: update_cache=true name="{{ item }}"
-  with_items: packages
+  with_items:
+    - python-software-properties
+    - "{% if tsuru_server_version is defined %}tsuru-server={{ tsuru_server_version }}{% else %}tsuru-server{% endif %}"
+    - "{% if tsuru_admin_version is defined %}tsuru-admin={{ tsuru_admin_version }}{% else %}tsuru-admin{% endif %}"
+    - "{% if tsuru_client_version is defined %}tsuru-client={{ tsuru_client_version }}{% else %}tsuru-client{% endif %}"
 
 - name: Copy configuration file.
   template: src=tsuru.conf.j2 dest=/etc/tsuru/tsuru.conf

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,23 @@
+---
+- hosts: all
+  sudo: yes
+  pre_tasks:
+     - name: Install MongoDB package
+       apt: name={{item}} state=present update_cache=yes
+       with_items:
+          - mongodb-server
+          - numactl
+  vars:
+    - tsuru_api_url: http://localhost
+    - mongodb_host: localhost
+    - mongodb_port: 27017
+    - gandalf_host_internal: localhost
+    - gandalf_host_external: localhost
+    - gandalf_port: 8081
+    - docker_registry_host: localhost
+    - docker_registry_port: 8082
+    - hipache_host_external_lb: localhost
+    - redis_host: localhost
+    - redis_port: 6379
+  roles:
+    - .

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,2 @@
 ---
 # vars file for tsuru_api
-
-packages:
-  - python-software-properties
-  - tsuru-server
-  - tsuru-admin
-  - tsuru-client


### PR DESCRIPTION
[Pin the versions of components that we use](https://www.pivotaltracker.com/story/show/98748824)

**What**

To prevent breaking changes of components (e.g. Tsuru API, MongoDB, etc) causing the platform to break we should pin or build to a particular version, this will ensure a consistent build.

This PR adds version control for [tsuru-api](https://tsuru.io)

**How to review this PR**

This PR has been written to be reviewed in the following context:
- I want to create a vagrant environment to help me develop and test locally
- I want to parameterise some of the packages so I would like to move them into the `task/main.yml` file so I can allow components of the `tsuru`  to be pinned to a specific version
- I want to remove the variables that I no longer use in `vars/main.yml` since I've moved them out into `task/main.yml'
- I want to update the documentation so others know how to pin the versions of `tsuru` components

**How to test this PR**

A vagrant box has been provided for testing.

```
$ vagrant up
```

You can supply the following snippet to the `test.yml` for testing version pinning:

```
vars:
  - tsuru_admin_version: 0.10.0-0~trusty1
  - tsuru_client_version: 0.16.0-0~trusty1
  - tsuru_server_version: 0.11.2-3~trusty1
```

**Who should review this PR**
- Anyone in the world, man, woman, child or  wooly mammoth!
