### PR TITLE
[#99773188] install latest packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   apt_repository: repo="{{ tsuru_repo }}" update_cache=yes
 
 - name: Install packages.
-  apt: update_cache=true name="{{ item }}"
+  apt: update_cache=true name="{{ item }}" state=latest
   with_items:
     - python-software-properties
     - "{% if tsuru_server_version is defined %}tsuru-server={{ tsuru_server_version }}{% else %}tsuru-server{% endif %}"


### PR DESCRIPTION
We want to install daily (nigtly built) snapshots of tsuru. To do this, we need to tell ansible to always install the latest packages. In case we want to keep other packages not being updated to latest, we can simply pin their version by configuring respective variables...
