### PR TITLE
[#99773188] Allow use of state = latest for apt installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Role Variables
 * `tsuru_server_version` - The version of the tsuru server package to be installed
 * `tsuru_client_version` - The version of the tsuru client package to be installed
 * `tsuru_admin_version` - The version of the tsuru admin package to be installed
+* `tsuru_package_latest` - Install the latest version of all packages, note this is mutually exclusive with options, `tsuru_server_version`, `tsuru_client_version` and `tsuru_admin_version`
 * `tsuru_repo` repo argument for Ansible's [`apt_repository`](http://docs.ansible.com/ansible/apt_repository_module.html) module, defaults to `ppa:tsuru/ppa`
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,12 +5,12 @@
   apt_repository: repo="{{ tsuru_repo }}" update_cache=yes
 
 - name: Install packages.
-  apt: update_cache=true name="{{ item }}"
+  apt: update_cache=true name="{{ item }}" "state={% if tsuru_package_latest is defined %}latest{% else %}present{% endif %}"
   with_items:
     - python-software-properties
-    - "{% if tsuru_server_version is defined %}tsuru-server={{ tsuru_server_version }}{% else %}tsuru-server{% endif %}"
-    - "{% if tsuru_admin_version is defined %}tsuru-admin={{ tsuru_admin_version }}{% else %}tsuru-admin{% endif %}"
-    - "{% if tsuru_client_version is defined %}tsuru-client={{ tsuru_client_version }}{% else %}tsuru-client{% endif %}"
+    - "tsuru-server{% if tsuru_server_version is defined and tsuru_package_latest is not defined %}={{ tsuru_server_version }}{% endif %}"
+    - "tsuru-admin{% if tsuru_admin_version is defined and tsuru_package_latest is not defined %}={{ tsuru_admin_version }}{% endif %}"
+    - "tsuru-client{% if tsuru_client_version is defined and tsuru_package_latest is not defined %}={{ tsuru_client_version }}{% endif %}"
 
 - name: Copy configuration file.
   template: src=tsuru.conf.j2 dest=/etc/tsuru/tsuru.conf

--- a/test.yml
+++ b/test.yml
@@ -19,5 +19,6 @@
     - hipache_host_external_lb: localhost
     - redis_host: localhost
     - redis_port: 6379
+    - tsuru_package_latest: true
   roles:
     - .


### PR DESCRIPTION
[Get a build of tsuru that supports vulcand](https://www.pivotaltracker.com/story/show/99773188)

**What**

This PR enables the use of `tsuru_package_latest: true` to allow someone to install the latest packages from a repository.

**How this PR should be reviewed**

I have written this PR to be reviewed in the following narrative:
- I would like to be able to install the latest packages from a specified repository

**How to test this PR**

A vagrant box has been provided so you can vagrant up and do the following:
- The current configuration point to the [tsuru stable](https://launchpad.net/~tsuru/+archive/ubuntu/ppa) repository so `vagrant provision` with that
- `vagrant ssh` into the vagrant box
- Do `apt-cache policy tsuru-server tsuru-admin tsuru-client` to see what ppa's and versions have been installed
- In order to test the update point to the [tsuru snapshots](https://launchpad.net/~tsuru/+archive/ubuntu/snapshots) repository by editing the `test.yml` file and adding:

```
vars:
...
  - tsuru_repo: 'ppa:tsuru/snapshots'
```
- Run `vagrant provision`
- `vagrant ssh` into the vagrant box
- Do `apt-cache policy tsuru-server tsuru-admin tsuru-client` to see what ppa's and versions have been installed

**Who should review this PR**
- A feisty feline but if none should be about then a member of the core team.
