### PR TITLE
[#9773312] Make router more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Role Variables
 * ` gandalf_host_external` - External hostname of the Gandalf server
 * ` gandalf_port ` - The port number upon which you wish to run Gandalf
 * ` gandalf_host_internal ` - The internal hostname of the Gandalf server.
-* `hipache_host_external_lb` - The external Hipache hostname for loadbalancer.
+* `tsuru_router_type` - Type of router.
+* `tsuru_router_config` - Hash of router config options. Must always include `domain`.
 * `redis_host` - The redis hostname.
 * `redis_port` - The redis port.
 * ` docker_registry_host ` - The Docker registry hostname.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,7 @@ healing_heal_containers_timeout: 10
 tsuru_api_listen_port: 8080
 tsuru_api_listen_addr: "0.0.0.0"
 tsuru_repo: 'ppa:tsuru/ppa'
+tsuru_router_type: 'hipache'
+tsuru_router_config:
+  domain: 'localhost'
+  redis-server: 'localhost:6379'

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -22,7 +22,7 @@ docker:
   registry: {{ docker_registry_host }}:{{ docker_registry_port }}
   collection: docker
   repository-namespace: tsuru
-  router: hipache
+  router: {{ tsuru_router_type }}
   deploy-cmd: /var/lib/tsuru/deploy
   run-cmd:
     bin: /var/lib/tsuru/start
@@ -35,10 +35,11 @@ docker:
     active-monitoring-interval: {{ healing_active_monitoring_interval }}
     heal-containers-timeout: {{ healing_heal_containers_timeout }}
 routers:
-  hipache:
-    type: hipache
-    domain: {{hipache_host_external_lb}}
-    redis-server: {{redis_host}}:{{redis_port}}
+  {{ tsuru_router_type }}:
+    type: {{ tsuru_router_type }}
+{% for key, val in tsuru_router_config.iteritems() %}
+    {{ key }}: {{ val }}
+{% endfor %}
 queue: redis
 pubsub:
   redis-host: {{redis_host}}

--- a/test.yml
+++ b/test.yml
@@ -16,7 +16,10 @@
     - gandalf_port: 8081
     - docker_registry_host: localhost
     - docker_registry_port: 8082
-    - hipache_host_external_lb: localhost
+    - tsuru_router_type: hipache
+    - tsuru_router_config:
+        domain: localhost
+        redis-server: localhost:6379
     - redis_host: localhost
     - redis_port: 6379
     - tsuru_package_latest: true


### PR DESCRIPTION
Replace `hipache_host_external_lb` with two new variables called
`tsuru_router_type` and `tsuru_router_config`. This will allow us to feature
flag the use of vulcand in our alphagov/tsuru-ansible codebase without
adding lots of new variables and conditional logic to this playbook.

I don't at this stage expect us to use more than one type of router in a
single installation. We can always add that later, if necessary.

NB: This is a breaking change and should be released as v0.2.0
