### PR TITLE
[#100310408] Fix Tsuru API snapshot version fail to start

### DIFF
--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -40,7 +40,9 @@ routers:
 {% for key, val in tsuru_router_config.iteritems() %}
     {{ key }}: {{ val }}
 {% endfor %}
-queue: redis
+queue:
+  mongo-url: {{mongodb_host}}:{{mongodb_port}}
+  mongo-database: queuedb
 pubsub:
   redis-host: {{redis_host}}
   redis-port: {{ redis_port}}


### PR DESCRIPTION
[#100310408 Tsuru API (snapshots / vulcand feature flag) fails to start](https://www.pivotaltracker.com/story/show/100310408)
## What

As part of testing vulcand as router to be able to setup custom SSL certificates, we need
to install the snapshot version of the api server, as described in #8 #9 .

The snapshot version of tsuru requires the configuration `queue:mongo-url` and `queue:mongo-database` set, despite the documentation still describes it as optional. In the latest versions of tsuru (>0.11.3) this queue is used for different internal tasks, included provisioner.
### How to review this PR

Using the previous configuration with the snapshot packages tsuru api (`make <gce|aws> DEPLOY_ENV=... ARGS='-e vulcand=true'`) it would fail starting with the following error in `/var/log/syslog`:

```
Aug  3 13:09:36 hector270715-tsuru-api-0 tsr[12548]: could not create queue instance, please check queue:mongo-url and queue:mongo-database config entries. error: no reachable se
rvers
Aug  3 13:09:36 hector270715-tsuru-api-0 kernel: [ 1910.699031] init: tsuru-server-api main process (12548) terminated with status 1
Aug  3 13:09:36 hector270715-tsuru-api-0 kernel: [ 1910.699041] init: tsuru-server-api main process ended, respawning
```

With the new configuration, it will start without problems.
### Who can review this?

Anyone but @dcarley or @keymon
